### PR TITLE
Fix and show enhanced demonstration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build/
 /.idea/
 *.iml
+.gradle

--- a/src/main/java/com/example/User.java
+++ b/src/main/java/com/example/User.java
@@ -1,10 +1,16 @@
 package com.example;
 
-import org.springframework.hateoas.ResourceSupport;
-
-public class User extends ResourceSupport {
+public class User {
 
     private String name;
+
+    public User() {
+        this.name = "";
+    }
+
+    public User(String name) {
+        this.name = name;
+    }
 
     public String getName() {
         return name;

--- a/src/test/java/com/example/UseRestTemplateTest.java
+++ b/src/test/java/com/example/UseRestTemplateTest.java
@@ -1,9 +1,22 @@
 package com.example;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.Resources;
 
 public class UseRestTemplateTest {
+
+    private static final Logger log = LoggerFactory.getLogger(UseRestTemplateTest.class);
 
     UseRestTemplate subject;
 
@@ -14,8 +27,23 @@ public class UseRestTemplateTest {
 
     @Test
     public void runRestOperations() {
-        subject.getUser();
-        subject.getUsers();
-        subject.saveUser();
+        Resource<User> newUser = subject.createUser("Test user");
+        assertThat(newUser.getContent().getName(), equalTo("Test user"));
+
+        Resource<User> user1 = subject.getUser();
+        assertThat(user1.getContent().getName(), equalTo("Test user"));
+
+        Resources<Resource<User>> users = subject.getUsers();
+        assertThat(users.getLinks().size(), equalTo(2));
+        assertThat(users.getLinks().get(0).getRel(), equalTo("self"));
+        assertThat(users.getLinks().get(0).getHref(), equalTo("http://localhost:8080/users"));
+
+        List<Resource<User>> userList = new ArrayList<>(users.getContent());
+        assertThat(userList.size(), equalTo(4));
+        assertThat(userList.get(0).getLinks().size(), equalTo(2));
+        assertThat(userList.get(0).getContent().getName(), equalTo("Test user"));
+
+        Resource<User> user2 = subject.saveUser();
+        assertThat(user2.getContent().getName(), equalTo("modified user"));
     }
 }


### PR DESCRIPTION
* No need to have User extend ResourceSupport if you're going to consume SDR using Resource<User>
* Altered your API to return the objects it fetched to make them assertable in test cases.
* Since this deals with an external system, I added a PUT to initialize the test case to a consistent state.
* Demonstrate how User, Resource<User>, and Resources<Resource<User>> can be used to POST/PATCH and retrieve single resources as well as collections.